### PR TITLE
Fix for the privilege escalation bug raised in issue #22.

### DIFF
--- a/conf.d/job-output.tpl
+++ b/conf.d/job-output.tpl
@@ -1,4 +1,4 @@
-<p>The last $OUTPUT_LINES of <i>$OUTPUT_FILE</i> are shown below:</p>
+<p>The last $OUTPUT_LINES lines of <i>$OUTPUT_FILE</i> are shown below:</p>
 
 <pre>
 $JOB_OUTPUT


### PR DESCRIPTION
In case you're wondering, I also changed the order of the fields in the sacct command to ensure that JobName comes last. This is because a job name can contain the pipe symbol and **may** cause issues with split commands (e.g. a carefully crafted job name still managing to trick the new seteuid and setegid system calls into using ID 0). I think this had already been accounted for by making sure the length of the list looked sane... but I didn't think it would hurt to use split("|", X) where we limit the number of splits to something we are expecting and then assuming anything remaining is the JobName.