### PR TITLE
Fix bug when Elapsed time is reported as 0

### DIFF
--- a/bin/slurm-send-mail.py
+++ b/bin/slurm-send-mail.py
@@ -232,10 +232,11 @@ class Job:
                 self.__wc_accuracy = (
                     (float(self.elapsed) / float(self.wallclock)) * 100.0
                 )
-            self.__cpu_time_usec = self.elapsed * self.__cpus * 1000000
-            self.__cpu_efficiency = (
-                    float(self.used_cpu_usec) / float(self.__cpu_time_usec)
-                ) * 100.0
+            if self.elapsed > 0:
+                self.__cpu_time_usec = self.elapsed * self.__cpus * 1000000
+                self.__cpu_efficiency = (
+                        float(self.used_cpu_usec) / float(self.__cpu_time_usec)
+                    ) * 100.0
 
     def separate_output(self) -> bool:
         return self.stderr == self.stdout


### PR DESCRIPTION
When Elapsed is 0, a divide by zero error occurs:
ERROR: float division by zero
Traceback (most recent call last):
  File "/opt/slurm/etc/slurm-mail/bin/slurm-send-mail.py", line 683, in <module>
    process_spool_file(f, int(fields[0]), fields[1])
  File "/opt/slurm/etc/slurm-mail/bin/slurm-send-mail.py", line 433, in process_spool_file
    job.save()
  File "/opt/slurm/etc/slurm-mail/bin/slurm-send-mail.py", line 237, in save
    float(self.used_cpu_usec) / float(self.__cpu_time_usec)
ZeroDivisionError: float division by zero