### PR TITLE
Fix issue with slurm-mail sending emails for each job of an array job

### DIFF
--- a/bin/slurm-spool-mail.py
+++ b/bin/slurm-spool-mail.py
@@ -109,17 +109,25 @@ if __name__ == "__main__":
         info = sys.argv[2].split(',')[0]
         logging.debug("info str: {0}".format(info))
         match = re.search(
-            r"Job_id=(?P<job_id>[0-9]+).*?(?P<action>[\w]+)$", info
+            r"^(?P<mail_type>.+?(?=Job_id))Job_id=(?P<job_id>[0-9]+|[0-9]+_[0-9]+|[0-9]+_\*)\ .*?(?P<action>[\w]+)$", info
         )
         if not match:
             die("Failed to parse Slurm info.")
 
-        logging.debug("Job ID: {0}".format(match.group("job_id")))
+        if "Summary" in match.group("mail_type"):
+            mail_type = "summary"
+            job_id = match.group("job_id").split('_')[0]
+        else:
+            mail_type = "individual"
+            job_id = match.group("job_id")
+
+        logging.debug("Mail Type: {0}".format(mail_type))
+        logging.debug("Job ID: {0}".format(job_id))
         logging.debug("Action: {0}".format(match.group("action")))
         logging.debug("User: {0}".format(sys.argv[3]))
 
         path = pathlib.Path(spool_dir).joinpath(
-            "{0}.{1}.mail".format(match.group("job_id"), match.group("action"))
+            "{0}.{1}.{2}.mail".format(job_id, match.group("action"), mail_type)
         )
         logging.debug("Job ID match, writing file {0}".format(path))
         with path.open(mode="w") as f:

--- a/conf.d/ended-array-summary.tpl
+++ b/conf.d/ended-array-summary.tpl
@@ -1,0 +1,28 @@
+<html>
+<head>
+<style>
+	$CSS
+</style>
+</head>
+<body>
+
+<p>Dear $USER,</p>
+
+<p>The last job in array $ARRAY_JOB_ID has $END_TXT on $CLUSTER.</p>
+
+<p>Details about this job can be found in the table below:</p>
+
+$JOB_TABLE
+
+$JOB_OUTPUT
+
+<p>Note: you will not receive e-mail notifications when other jobs in your job array complete. To receive individual job completion e-mails for each job in your next array, add the "ARRAY_TASKS" option to the mail-type SBATCH parameter.</p>
+
+<p>Regards,</p>
+
+<p>$EMAIL_FROM</p>
+
+<p><i>Note: This is an automated e-mail.</i></p>
+
+</body>
+</html>

--- a/conf.d/started-array-summary.tpl
+++ b/conf.d/started-array-summary.tpl
@@ -1,0 +1,30 @@
+<html>
+<head>
+<style>
+	$CSS
+
+	tr.jobEnd {
+		display: none;
+	}
+</style>
+</head>
+<body>
+
+<p>Dear $USER,</p>
+
+<p>The first job in array $ARRAY_JOB_ID has started on $CLUSTER.</p>
+
+<p>Details about this job can be found in the table below:</p>
+
+$JOB_TABLE
+
+<p>Note: you will not receive e-mail notifications when other jobs in your job array start. To receive individual job start e-mails for each job in your next array, add the "ARRAY_TASKS" option to the mail-type SBATCH parameter.</p>
+
+<p>Regards,</p>
+
+<p>$EMAIL_FROM</p>
+
+<p><i>Note: This is an automated e-mail.</i></p>
+
+</body>
+</html>

--- a/conf.d/started-array.tpl
+++ b/conf.d/started-array.tpl
@@ -12,13 +12,11 @@
 
 <p>Dear $USER,</p>
 
-<p>The first job in array $ARRAY_JOB_ID has started on $CLUSTER.</p>
+<p>Your job $JOB_ID of job array $ARRAY_JOB_ID has started on $CLUSTER.</p>
 
 <p>Details about this job can be found in the table below:</p>
 
 $JOB_TABLE
-
-<p>Note: you will not receive e-mail notifications when other jobs in your job array start. However, you will receive individual job completion e-mails for each job in the array if you have requested job completion e-mails in your job submission.</p>
 
 <p>Regards,</p>
 


### PR DESCRIPTION
rather than a summary when not using ARRAY_TASKS mail-type option

From the manual page for sbatch:
"Unless the ARRAY_TASKS option is specified, mail notifications on job
BEGIN, END and FAIL apply to a job array as a whole rather than
generating individual email messages for  each  task in the job array.

When the ARRAY_TASKS mail option is used in conjunction with begin,
end, or fail one email should be sent for each array task for each
condition. A job with --array=1_3 and mail-type=begin,end,array_tasks
should send 3 begin emails 3 end emails. This was working as expected.

When ARRAY_TASKS mail option is not used, there should be one email
sent when the first job of an array begins and one email when the last
array job completes. This was not working as expected.

Prior to this commit, slurm-mail was not handling array emails as
described in the sbatch manual or as it is described by the "note"
in the array began template. When not using ARRAY_TASKS, slurm-mail
was sending one email for each job begin and each job end in an array.
It should have been sending gone begin email and one end email.

The note in the begin array template states:
"Note: you will not receive e-mail notifications when other jobs in
your job array start. However, you will receive individual job
completion e-mails for each job in the array if you have requested
job completion e-mails in your job submission."
This is not true as slurm-mail was sending a begin email for each
array job that started when using --array=1-2 --mail-type=begin,end.