### PR TITLE
add limit for array notifications

### DIFF
--- a/bin/slurm-send-mail.py
+++ b/bin/slurm-send-mail.py
@@ -499,6 +499,11 @@ def process_spool_file(json_file: pathlib.Path):
     if array_summary or len(jobs) == 1:
         jobs = [jobs[0]]
 
+    if len(jobs) > array_max_notifications:
+        logging.info("Asked to send notifications for %d array-jobs, which exceeds the limit %d. "
+            + "Will send only the first one.", len(jobs), array_max_notifications)
+        jobs = [jobs[0]]
+
     for job in jobs:
         # Will only be one job regardless of if it is an array in the
         # "began" state. For jobs that have ended there can be mulitple
@@ -763,6 +768,7 @@ if __name__ == "__main__":
         smtp_password = config.get(section, "smtpPassword")
         tail_exe = config.get(section, "tailExe")
         tail_lines = config.getint(section, "includeOutputLines")
+        array_max_notifications = config.getint(section, "arrayMaxNotifications")
     except Exception as e:
         die("Error: {0}".format(e))
 

--- a/conf.d/slurm-mail.conf
+++ b/conf.d/slurm-mail.conf
@@ -26,3 +26,4 @@ smtpUserName =
 smtpPassword =
 tailExe = /usr/bin/tail
 includeOutputLines = 0
+arrayMaxNotifications = 100


### PR DESCRIPTION
For large arrays it is doubtful whether indeed thousands of e-mails should be sent. This PR introduces the option to limit this.

I'm not sure whether the approach of simply sending the first one is good. Would it make sense to also set

    jobs[0].is_array=1

in order to get a summary?