### PR TITLE
add additional template variables START_TS and END_TS

### DIFF
--- a/bin/slurm-send-mail.py
+++ b/bin/slurm-send-mail.py
@@ -535,6 +535,7 @@ def process_spool_file(json_file: pathlib.Path, smtp_conn: smtplib.SMTP):
         job_table = tpl.substitute(
             JOB_ID=job.id, JOB_NAME=job.name, PARTITION=job.partition,
             START=job.start, END=job.end, WORKDIR=job.workdir,
+            START_TS=job.start_ts, END_TS=job.end_ts,
             ELAPSED=str(timedelta(seconds=job.elapsed)), EXIT_STATE=job.state,
             EXIT_CODE=job.exit_code, COMMENT=job.comment,
             MEMORY=job.requested_mem_str, MAX_MEMORY=job.max_rss_str,


### PR DESCRIPTION
Sometimes it's useful to have the epoch timestamps of the job start / end time available in templates. Specifically, we'd like to do something like

    <p>Additional information on the jobs resource usage can be found on the
    <a href="https://example.com/d/job-details?orgId=1&var-job=$JOB_ID&from=${START_TS}000&to=${END_TS}000">dashboards</a>.</p>

In case that's actually useful to other users, it might make sense to include it upstream.