### PR TITLE
Fixed CPU Time not parsed properly when the TotalCPU column does not contain usec

### DIFF
--- a/bin/slurm-send-mail.py
+++ b/bin/slurm-send-mail.py
@@ -329,7 +329,7 @@ def get_usec_from_str(time_str: str) -> int:
         long_time_str = u"%s.0" % time_str
     else:
         long_time_str = time_str
-    
+
     timeRe = re.compile(
         r"((?P<days>\d+)-)?((?P<hours>\d+):)?(?P<mins>\d+):(?P<secs>\d+).(?P<usec>\d+)"
     )

--- a/bin/slurm-send-mail.py
+++ b/bin/slurm-send-mail.py
@@ -325,19 +325,16 @@ def get_usec_from_str(time_str: str) -> int:
     """
     Convert a Slurm elapsed time string into microseconds.
     """
-    if "." not in time_str:
-        long_time_str = "%s.0" % time_str
-    else:
-        long_time_str = time_str
-
     timeRe = re.compile(
-        r"((?P<days>\d+)-)?((?P<hours>\d+):)?(?P<mins>\d+):(?P<secs>\d+).(?P<usec>\d+)"
+        r"((?P<days>\d+)-)?((?P<hours>\d+):)?(?P<mins>\d+):(?P<secs>\d+)(\.(?P<usec>\d+))?"
     )
-    match = timeRe.match(long_time_str)
+    match = timeRe.match(time_str)
     if not match:
-        die("Could not parse: {0}".format(long_time_str))
+        die("Could not parse: {0}".format(time_str))
 
-    usec = int(match.group("usec"))
+    usec = 0
+    if match.group("usec"):
+        usec += int(match.group("usec"))
     usec += int(match.group("secs")) * 1000000
     usec += int(match.group("mins")) * 1000000 * 60
     if match.group("hours"):

--- a/bin/slurm-send-mail.py
+++ b/bin/slurm-send-mail.py
@@ -325,12 +325,17 @@ def get_usec_from_str(time_str: str) -> int:
     """
     Convert a Slurm elapsed time string into microseconds.
     """
+    if "." not in time_str:
+        long_time_str = u"%s.0" % time_str
+    else:
+	    long_time_str = time_str
+    
     timeRe = re.compile(
         r"((?P<days>\d+)-)?((?P<hours>\d+):)?(?P<mins>\d+):(?P<secs>\d+).(?P<usec>\d+)"
     )
-    match = timeRe.match(time_str)
+    match = timeRe.match(long_time_str)
     if not match:
-        die("Could not parse: {0}".format(time_str))
+        die("Could not parse: {0}".format(long_time_str))
 
     usec = int(match.group("usec"))
     usec += int(match.group("secs")) * 1000000

--- a/bin/slurm-send-mail.py
+++ b/bin/slurm-send-mail.py
@@ -328,7 +328,7 @@ def get_usec_from_str(time_str: str) -> int:
     if "." not in time_str:
         long_time_str = u"%s.0" % time_str
     else:
-	    long_time_str = time_str
+        long_time_str = time_str
     
     timeRe = re.compile(
         r"((?P<days>\d+)-)?((?P<hours>\d+):)?(?P<mins>\d+):(?P<secs>\d+).(?P<usec>\d+)"

--- a/bin/slurm-send-mail.py
+++ b/bin/slurm-send-mail.py
@@ -326,7 +326,7 @@ def get_usec_from_str(time_str: str) -> int:
     Convert a Slurm elapsed time string into microseconds.
     """
     if "." not in time_str:
-        long_time_str = u"%s.0" % time_str
+        long_time_str = "%s.0" % time_str
     else:
         long_time_str = time_str
 


### PR DESCRIPTION
The usec portion of the CPU Time is not properly parsed when the `TotalCPU` column from `sacct` command does not contain usec, for example `1:00:00` instead of `1:00:00.0`. Appending `.0` to the end of TotalCPU column will resolve this issue. This will also indirectly resolve CPU Efficiency calculation, as it depends on the value of CPU Time.

I am not sure if this problem apply to all the SLURM version, as we have only tested on version `21.08.8-2` in our cluster.