### PR TITLE
fix logrotate config

### DIFF
--- a/logrotate.d/slurm-mail
+++ b/logrotate.d/slurm-mail
@@ -1,7 +1,7 @@
-/var/log/slurm-mail/*
+/var/log/slurm-mail/*.log
 {
     missingok
     weekly
     compress
-    rotate 5 
+    rotate 5
 }


### PR DESCRIPTION
with just `/*` the resulting *.gz files will be rotated as well, which results in a mess:

    slurm-send-mail.log                                                                  
    slurm-send-mail.log.1.gz                                                             
    slurm-send-mail.log.1.gz.1.gz                                                        
    slurm-send-mail.log.1.gz.1.gz.1.gz                                                   
    slurm-send-mail.log.1.gz.1.gz.1.gz.1.gz                                              
    slurm-send-mail.log.1.gz.1.gz.1.gz.1.gz.1.gz
    …