### PR TITLE
#57 - Cannot build RPM on CentOS with new version if slurmmail is already installed

### DIFF
--- a/build-tools/get-property.py
+++ b/build-tools/get-property.py
@@ -33,7 +33,7 @@ import argparse
 import pathlib
 import sys
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 import slurmmail  # pylint: disable=wrong-import-position
 
 

--- a/build-tools/process-template.py
+++ b/build-tools/process-template.py
@@ -37,7 +37,7 @@ import sys
 
 from string import Template
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 import slurmmail  # pylint: disable=wrong-import-position
 
 from slurmmail.common import check_file, die, get_file_contents  # pylint: disable=wrong-import-position


### PR DESCRIPTION
The get-property.py and process-template.py include slurmmail, but because we append to sys.path instead of prepending, the globally installed slurmmail is found first if it is already installed. We prepend now instead.