### PR TITLE
Consider case when job start timestamp is none.

### DIFF
--- a/src/slurmmail/slurm.py
+++ b/src/slurmmail/slurm.py
@@ -199,7 +199,7 @@ class Job:
                 "A job's used CPU time must be set first"
             )
         #self.__cpu_wallclock = self.__wallclock * self.cpus
-        if self.__end_ts:
+        if self.__start_ts and self.__end_ts:
             self.elapsed = (self.__end_ts - self.__start_ts)
             if self.wallclock > 0:
                 self.__wc_accuracy = (


### PR DESCRIPTION
This is a minor fix for the following type of error:

2022/11/08 13:00:01:INFO: processing: /var/spool/slurm-mail/40_1667907496.6548867.mail
2022/11/08 13:00:02:DEBUG: Running /usr/bin/sacct -j 40 -P -n --fields=JobId,User,Group,Partition,Start,End,State,ReqMem,MaxRSS,NCPUS,TotalCPU,NNodes,WorkDir,Elapsed,ExitCode,Comment,Cluster,NodeList,TimeLimit,TimelimitRaw,JobIdRaw,JobName
2022/11/08 13:00:02:DEBUG: 40|[Redacted]|[Redacted]|long|None|1667907496|CANCELLED by 1000|192059M||128|00:00:00|1|[Redacted]|00:00:00|0:0||[Redacted]|None assigned|416-16:00:00|600000|40|bench

2022/11/08 13:00:02:WARNING: job 40: could not parse 'None' for job start timestamp
2022/11/08 13:00:02:DEBUG: Running /usr/bin/scontrol -o show job=40
2022/11/08 13:00:02:ERROR: Failed to run: /usr/bin/scontrol -o show job=40
2022/11/08 13:00:02:ERROR: 
2022/11/08 13:00:02:ERROR: slurm_load_jobs error: Invalid job id specified

2022/11/08 13:00:02:ERROR: Failed to process: /var/spool/slurm-mail/40_1667907496.6548867.mail
2022/11/08 13:00:02:ERROR: unsupported operand type(s) for -: 'int' and 'NoneType'
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/slurmmail-4.0-py3.10.egg/slurmmail/cli.py", line 582, in send_mail_main
    __process_spool_file(f, smtp_conn, options)
  File "/usr/local/lib/python3.10/site-packages/slurmmail-4.0-py3.10.egg/slurmmail/cli.py", line 275, in __process_spool_file
    job.save()
  File "/usr/local/lib/python3.10/site-packages/slurmmail-4.0-py3.10.egg/slurmmail/slurm.py", line 203, in save
    self.elapsed = (self.__end_ts - self.__start_ts)
TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'
