### PR TITLE
Fix Docker Slurm workflows

### DIFF
--- a/.github/workflows/build_docker_slurm.yml
+++ b/.github/workflows/build_docker_slurm.yml
@@ -40,6 +40,6 @@ jobs:
         run: |
           docker build --build-arg SLURM_VER=${{ steps.get_slurm_version.outputs.slurm_version }} -f Dockerfile.${{ matrix.os }} -t ghcr.io/neilmunday/slurm-mail/slurm-${{ matrix.os }}:${{ steps.get_slurm_version.outputs.slurm_version }} -t ghcr.io/neilmunday/slurm-mail/slurm-${{ matrix.os }}:latest .
       - name: Push Docker image ghcr.io/neilmunday/slurm-mail/slurm-${{ matrix.os }}:${{ steps.get_slurm_version.outputs.slurm_version }}
-        if: github.event.pull_request.merged == true
+        if: github.event_name == 'push'
         run: |
           docker push -a ghcr.io/neilmunday/slurm-mail/slurm-${{ matrix.os }}

--- a/.github/workflows/slurm_version_check.yml
+++ b/.github/workflows/slurm_version_check.yml
@@ -64,6 +64,7 @@ jobs:
       - name: create pull request
         if: steps.check.outputs.proceed == '1'
         env:
-          GH_TOKEN: ${{ github.token }}
+          # need to use a PAT otherwise other workflows will not run
+          GH_TOKEN: ${{ secrets.PRPAT }}
         run: |
           gh pr create -a neilmunday -f


### PR DESCRIPTION
This PR fixes the Docker Slurm workflows so that upon a pull request, the `build_docker_slurm` workflow is triggered as well as being triggered on merging to updated the image repository.