### PR TITLE
remove-depends-on-slurmctld from rpm specfile

### DIFF
--- a/build-tools/slurm-mail.spec.tpl
+++ b/build-tools/slurm-mail.spec.tpl
@@ -31,10 +31,6 @@ Source: %{name}-%{version}.tar.gz
 %{?sle_version:Requires: python3}
 Requires:   cronie
 Requires:   logrotate
-%{?el7:Requires: slurm-slurmctld}
-%{?el8:Requires: slurm-slurmctld}
-%{?el9:Requires: slurm-slurmctld}
-%{?sle_version:Requires: slurm}
 
 %description
 $LONG_DESCRIPTION


### PR DESCRIPTION
#92 
removing the Requires as they are not required and can break systems