### PR TITLE
Fixed incomplete information was passed to the spooler regex

### DIFF
--- a/etc/slurm-mail/templates/job-table.tpl
+++ b/etc/slurm-mail/templates/job-table.tpl
@@ -35,6 +35,10 @@
 		<td>Work dir:</td>
 		<td>$WORKDIR</td>
 	</tr>
+	<tr class="jobEnd">
+		<td>Admin Comment:</td>
+		<td>$ADMIN_COMMENT</td>
+	</tr>
 	<tr>
 		<td>Comment:</td>
 		<td>$COMMENT</td>

--- a/src/slurmmail/cli.py
+++ b/src/slurmmail/cli.py
@@ -184,6 +184,7 @@ def __process_spool_file(
             "WorkDir",
             "Elapsed",
             "ExitCode",
+            "AdminComment",
             "Comment",
             "Cluster",
             "NodeList",
@@ -244,6 +245,7 @@ def __process_spool_file(
                     job = Job(options.datetime_format, job_id)
 
                 job.cluster = sacct_dict["Cluster"]
+                job.admin_comment = sacct_dict["AdminComment"]
                 job.comment = sacct_dict["Comment"]
                 job.cpus = int(sacct_dict["NCPUS"])
                 job.group = sacct_dict["Group"]
@@ -379,6 +381,7 @@ def __process_spool_file(
             ELAPSED=str(timedelta(seconds=job.elapsed)),
             EXIT_STATE=job.state,
             EXIT_CODE=job.exit_code,
+            ADMIN_COMMENT=job.admin_comment,
             COMMENT=job.comment,
             MEMORY=job.requested_mem_str,
             MAX_MEMORY=job.max_rss_str,

--- a/src/slurmmail/cli.py
+++ b/src/slurmmail/cli.py
@@ -790,10 +790,10 @@ def spool_mail_main():
         die("Incorrect number of command line arguments")
 
     try:
-        info = ",".join(sys.argv[2].split(",")[0:-1])
         logging.debug("info str: %s", info)
         match = None
-        if "Array" in info:
+        if "Array" in sys.argv[2]:
+            info = ",".join(sys.argv[2].split(","))
             match = re.search(
                 r"Slurm ((?P<array_summary>Array Summary)|Array Task)"
                 r" Job_id=[0-9]+_([0-9]+|\*)"
@@ -806,6 +806,7 @@ def spool_mail_main():
                 die("Failed to parse Slurm info.")
             array_summary = match.group("array_summary") is not None
         else:
+            info = ",".join(sys.argv[2].split(",")[0:-1])
             match = re.search(
                 r"Slurm"
                 r" Job_id=(?P<job_id>[0-9]+).*?(?P<state>(Began|Ended|Failed|Requeued|Invalid"  # noqa

--- a/src/slurmmail/cli.py
+++ b/src/slurmmail/cli.py
@@ -790,7 +790,7 @@ def spool_mail_main():
         die("Incorrect number of command line arguments")
 
     try:
-        info = sys.argv[2].split(",", maxsplit=1)[0]
+        info = ",".join(sys.argv[2].split(",")[0:-1])
         logging.debug("info str: %s", info)
         match = None
         if "Array" in info:

--- a/src/slurmmail/cli.py
+++ b/src/slurmmail/cli.py
@@ -790,10 +790,10 @@ def spool_mail_main():
         die("Incorrect number of command line arguments")
 
     try:
-        logging.debug("info str: %s", info)
         match = None
         if "Array" in sys.argv[2]:
             info = ",".join(sys.argv[2].split(","))
+            logging.debug("info str: %s", info)
             match = re.search(
                 r"Slurm ((?P<array_summary>Array Summary)|Array Task)"
                 r" Job_id=[0-9]+_([0-9]+|\*)"
@@ -807,6 +807,7 @@ def spool_mail_main():
             array_summary = match.group("array_summary") is not None
         else:
             info = ",".join(sys.argv[2].split(",")[0:-1])
+            logging.debug("info str: %s", info)
             match = re.search(
                 r"Slurm"
                 r" Job_id=(?P<job_id>[0-9]+).*?(?P<state>(Began|Ended|Failed|Requeued|Invalid"  # noqa

--- a/src/slurmmail/cli.py
+++ b/src/slurmmail/cli.py
@@ -790,10 +790,10 @@ def spool_mail_main():
         die("Incorrect number of command line arguments")
 
     try:
+        info = ",".join(sys.argv[2].split(","))
+        logging.debug("info str: %s", info)
         match = None
-        if "Array" in sys.argv[2]:
-            info = ",".join(sys.argv[2].split(","))
-            logging.debug("info str: %s", info)
+        if "Array" in info:
             match = re.search(
                 r"Slurm ((?P<array_summary>Array Summary)|Array Task)"
                 r" Job_id=[0-9]+_([0-9]+|\*)"
@@ -806,8 +806,6 @@ def spool_mail_main():
                 die("Failed to parse Slurm info.")
             array_summary = match.group("array_summary") is not None
         else:
-            info = ",".join(sys.argv[2].split(",")[0:-1])
-            logging.debug("info str: %s", info)
             match = re.search(
                 r"Slurm"
                 r" Job_id=(?P<job_id>[0-9]+).*?(?P<state>(Began|Ended|Failed|Requeued|Invalid"  # noqa

--- a/src/slurmmail/cli.py
+++ b/src/slurmmail/cli.py
@@ -790,7 +790,7 @@ def spool_mail_main():
         die("Incorrect number of command line arguments")
 
     try:
-        info = ",".join(sys.argv[2].split(","))
+        info = sys.argv[2]
         logging.debug("info str: %s", info)
         match = None
         if "Array" in info:

--- a/src/slurmmail/slurm.py
+++ b/src/slurmmail/slurm.py
@@ -87,6 +87,7 @@ class Job:
 
         self.array_id: Optional[int] = array_id
         self.cluster: Optional[str] = None
+        self.admin_comment: Optional[str] = None
         self.comment: Optional[str] = None
         self.elapsed: Optional[int] = 0
         self.exit_code: Optional[int] = None


### PR DESCRIPTION
Hi @neilmunday, there was an issue parsing job information when spooling a new email if the job name contain comma symbol, for example `1,2-R-Triazole-Cu2+`. Since comma is used as the delimiter to extract the information, the part after the comma in the job name will be missing after the split for the regex to capture the match. This problem does not occur with other symbol other than comma as far as I have tested.

I have adjusted the code to properly read the full job name so that the regex search can function properly.