### PR TITLE
Fixed incomplete information was passed to spooler regex

### DIFF
--- a/build-tools/process-template.py
+++ b/build-tools/process-template.py
@@ -60,7 +60,7 @@ def write_file(template_path: pathlib.Path, write_path: pathlib.Path):
                 VERSION=slurmmail.VERSION
             )
         )
-    logging.debug("wrote: %s", output_path)
+    logging.debug("wrote: %s", write_path)
 
 if __name__ == "__main__":
 

--- a/src/slurmmail/cli.py
+++ b/src/slurmmail/cli.py
@@ -790,7 +790,7 @@ def spool_mail_main():
         die("Incorrect number of command line arguments")
 
     try:
-        info = sys.argv[2].split(",", maxsplit=1)[0]
+        info = sys.argv[2]
         logging.debug("info str: %s", info)
         match = None
         if "Array" in info:


### PR DESCRIPTION
Hi @neilmunday, there was an issue parsing job information when spooling a new email if the job name contain comma symbol, for example `1,2-R-Triazole-Cu2+`. Since comma is used as the delimiter to extract the information, the part after the comma in the job name will be missing after the split for the regex to capture the match. This problem does not occur with other symbol other than comma as far as I have tested.

I have adjusted the code to properly read the full job name so that the regex search can function properly. The code has been tested on slurm-v23.06.2 on both Array and non-Array jobs.