### PR TITLE
Added Admin Comment field to Job Information Table

### DIFF
--- a/etc/slurm-mail/templates/job-table.tpl
+++ b/etc/slurm-mail/templates/job-table.tpl
@@ -35,6 +35,10 @@
 		<td>Work dir:</td>
 		<td>$WORKDIR</td>
 	</tr>
+	<tr class="jobEnd">
+		<td>Admin Comment:</td>
+		<td>$ADMIN_COMMENT</td>
+	</tr>
 	<tr>
 		<td>Comment:</td>
 		<td>$COMMENT</td>

--- a/src/slurmmail/cli.py
+++ b/src/slurmmail/cli.py
@@ -184,6 +184,7 @@ def __process_spool_file(
             "WorkDir",
             "Elapsed",
             "ExitCode",
+            "AdminComment",
             "Comment",
             "Cluster",
             "NodeList",
@@ -244,6 +245,7 @@ def __process_spool_file(
                     job = Job(options.datetime_format, job_id)
 
                 job.cluster = sacct_dict["Cluster"]
+                job.admin_comment = sacct_dict["AdminComment"]
                 job.comment = sacct_dict["Comment"]
                 job.cpus = int(sacct_dict["NCPUS"])
                 job.group = sacct_dict["Group"]
@@ -379,6 +381,7 @@ def __process_spool_file(
             ELAPSED=str(timedelta(seconds=job.elapsed)),
             EXIT_STATE=job.state,
             EXIT_CODE=job.exit_code,
+            ADMIN_COMMENT=job.admin_comment,
             COMMENT=job.comment,
             MEMORY=job.requested_mem_str,
             MAX_MEMORY=job.max_rss_str,

--- a/src/slurmmail/slurm.py
+++ b/src/slurmmail/slurm.py
@@ -87,6 +87,7 @@ class Job:
 
         self.array_id: Optional[int] = array_id
         self.cluster: Optional[str] = None
+        self.admin_comment: Optional[str] = None
         self.comment: Optional[str] = None
         self.elapsed: Optional[int] = 0
         self.exit_code: Optional[int] = None

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -476,8 +476,8 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "1|root|root|all|1674333232|Unknown|RUNNING|500M||1|00:00:00|1|/|00:00:11|0:0||test|node01|01:00:00|60|1|test.jcf\n"  # noqa
-            sacct_output += "1.batch||||1674333232|Unknown|RUNNING|||1|00:00:00|1||00:00:11|0:0||test|node01|||1.batch|batch"  # noqa
+            sacct_output = "1|root|root|all|1674333232|Unknown|RUNNING|500M||1|00:00:00|1|/|00:00:11|0:0|||test|node01|01:00:00|60|1|test.jcf\n"  # noqa
+            sacct_output += "1.batch||||1674333232|Unknown|RUNNING|||1|00:00:00|1||00:00:11|0:0|||test|node01|||1.batch|batch"  # noqa
             mock_slurmmail_cli_run_command.side_effect = [(0, sacct_output, "")]
             slurmmail.cli.__dict__["__process_spool_file"](
                 pathlib.Path("/tmp/foo"),
@@ -511,8 +511,8 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "2|root|root|all|1674340451|1674340571|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0||test|node01|01:00:00|60|2|test.jcf\n"  # noqa
-            sacct_output += "2.batch||||1674340451|1674340571|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0||test|node01|||2.batch|batch"  # noqa
+            sacct_output = "2|root|root|all|1674340451|1674340571|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0|||test|node01|01:00:00|60|2|test.jcf\n"  # noqa
+            sacct_output += "2.batch||||1674340451|1674340571|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0|||test|node01|||2.batch|batch"  # noqa
             scontrol_output = (
                 "JobId=2 JobName=test.jcf UserId=root(0) GroupId=root(0) MCS_label=N/A"
                 " Priority=4294901758 Nice=0 Account=root QOS=normal JobState=COMPLETED"
@@ -579,8 +579,8 @@ class TestProcessSpoolFile:
             mock_slurmmail_cli_process_spool_file_options.tail_exe = pathlib.Path(
                 "/usr/bin/tail"
             )
-            sacct_output = "2|root|root|all|1674340451|1674340571|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0||test|node01|01:00:00|60|2|test.jcf\n"  # noqa
-            sacct_output += "2.batch||||1674340451|1674340571|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0||test|node01|||2.batch|batch"  # noqa
+            sacct_output = "2|root|root|all|1674340451|1674340571|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0|||test|node01|01:00:00|60|2|test.jcf\n"  # noqa
+            sacct_output += "2.batch||||1674340451|1674340571|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0|||test|node01|||2.batch|batch"  # noqa
             scontrol_output = (
                 "JobId=2 JobName=test.jcf UserId=root(0) GroupId=root(0) MCS_label=N/A"
                 " Priority=4294901758 Nice=0 Account=root QOS=normal JobState=COMPLETED"
@@ -640,8 +640,8 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "7_0|root|root|all|1675460419|Unknown|RUNNING|500M||1|00:00:00|1|/root|00:00:43|0:0||test|node01|00:05:00|5|8|test.jcf\n"  # noqa
-            sacct_output += "7_0.batch||||1675460419|Unknown|RUNNING|||1|00:00:00|1||00:00:43|0:0||test|node01|||8.batch|batch\n"  # noqa
+            sacct_output = "7_0|root|root|all|1675460419|Unknown|RUNNING|500M||1|00:00:00|1|/root|00:00:43|0:0|||test|node01|00:05:00|5|8|test.jcf\n"  # noqa
+            sacct_output += "7_0.batch||||1675460419|Unknown|RUNNING|||1|00:00:00|1||00:00:43|0:0|||test|node01|||8.batch|batch\n"  # noqa
             sacct_output += (
                 "7_1|root|root|all|Unknown|Unknown|PENDING|500M||1|00:00:00|1|/root|00:00:00|0:0||test|None"  # noqa
                 " assigned|00:05:00|5|7|test.jcf"
@@ -679,10 +679,10 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "7_0|root|root|all|1675460419|1675460599|COMPLETED|500M||1|00:00.010|1|/root|00:03:00|0:0||test|node01|00:05:00|5|8|test.jcf\n"  # noqa
-            sacct_output += "7_0.batch||||1675460419|1675460599|COMPLETED||4832K|1|00:00.010|1||00:03:00|0:0||test|node01|||8.batch|batch\n"  # noqa
-            sacct_output += "7_1|root|root|all|1675460599|1675460779|COMPLETED|500M||1|00:00.010|1|/root|00:03:00|0:0||test|node01|00:05:00|5|7|test.jcf\n"  # noqa
-            sacct_output += "7_1.batch||||1675460599|1675460779|COMPLETED||4784K|1|00:00.010|1||00:03:00|0:0||test|node01|||7.batch|batch"  # noqa
+            sacct_output = "7_0|root|root|all|1675460419|1675460599|COMPLETED|500M||1|00:00.010|1|/root|00:03:00|0:0|||test|node01|00:05:00|5|8|test.jcf\n"  # noqa
+            sacct_output += "7_0.batch||||1675460419|1675460599|COMPLETED||4832K|1|00:00.010|1||00:03:00|0:0|||test|node01|||8.batch|batch\n"  # noqa
+            sacct_output += "7_1|root|root|all|1675460599|1675460779|COMPLETED|500M||1|00:00.010|1|/root|00:03:00|0:0|||test|node01|00:05:00|5|7|test.jcf\n"  # noqa
+            sacct_output += "7_1.batch||||1675460599|1675460779|COMPLETED||4784K|1|00:00.010|1||00:03:00|0:0|||test|node01|||7.batch|batch"  # noqa
             scontrol_output_1 = (
                 "JobId=8 ArrayJobId=7 ArrayTaskId=0 JobName=test.jcf UserId=root(0)"
                 " GroupId=root(0) MCS_label=N/A Priority=4294901756 Nice=0 Account=root"
@@ -777,10 +777,10 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "7_0|root|root|all|1675460419|1675460599|COMPLETED|500M||1|00:00.010|1|/root|00:03:00|0:0||test|node01|00:05:00|5|8|test.jcf\n"  # noqa
-            sacct_output += "7_0.batch||||1675460419|1675460599|COMPLETED||4832K|1|00:00.010|1||00:03:00|0:0||test|node01|||8.batch|batch\n"  # noqa
-            sacct_output += "7_1|root|root|all|1675460599|1675460779|COMPLETED|500M||1|00:00.010|1|/root|00:03:00|0:0||test|node01|00:05:00|5|7|test.jcf\n"  # noqa
-            sacct_output += "7_1.batch||||1675460599|1675460779|COMPLETED||4784K|1|00:00.010|1||00:03:00|0:0||test|node01|||7.batch|batch"  # noqa
+            sacct_output = "7_0|root|root|all|1675460419|1675460599|COMPLETED|500M||1|00:00.010|1|/root|00:03:00|0:0|||test|node01|00:05:00|5|8|test.jcf\n"  # noqa
+            sacct_output += "7_0.batch||||1675460419|1675460599|COMPLETED||4832K|1|00:00.010|1||00:03:00|0:0|||test|node01|||8.batch|batch\n"  # noqa
+            sacct_output += "7_1|root|root|all|1675460599|1675460779|COMPLETED|500M||1|00:00.010|1|/root|00:03:00|0:0|||test|node01|00:05:00|5|7|test.jcf\n"  # noqa
+            sacct_output += "7_1.batch||||1675460599|1675460779|COMPLETED||4784K|1|00:00.010|1||00:03:00|0:0|||test|node01|||7.batch|batch"  # noqa
             scontrol_output_1 = (
                 "JobId=8 ArrayJobId=7 ArrayTaskId=0 JobName=test.jcf UserId=root(0)"
                 " GroupId=root(0) MCS_label=N/A Priority=4294901756 Nice=0 Account=root"
@@ -879,8 +879,8 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "2|root|root|all|1674340451|1674340571|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0||test|node01|01:00:00|60|2|test.jcf\n"  # noqa
-            sacct_output += "2.batch||||1674340451|1674340571|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0||test|node01|||2.batch|batch"  # noqa
+            sacct_output = "2|root|root|all|1674340451|1674340571|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0|||test|node01|01:00:00|60|2|test.jcf\n"  # noqa
+            sacct_output += "2.batch||||1674340451|1674340571|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0|||test|node01|||2.batch|batch"  # noqa
             mock_slurmmail_cli_run_command.side_effect = [
                 (0, sacct_output, ""),
                 (1, "error", "error"),
@@ -918,8 +918,8 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "2|root|root|all|1674340451|1674340571|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0||test|node01|UNLIMITED||2|test.jcf\n"  # noqa
-            sacct_output += "2.batch||||1674340451|1674340571|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0||test|node01|||2.batch|batch"  # noqa
+            sacct_output = "2|root|root|all|1674340451|1674340571|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0|||test|node01|UNLIMITED||2|test.jcf\n"  # noqa
+            sacct_output += "2.batch||||1674340451|1674340571|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0|||test|node01|||2.batch|batch"  # noqa
             scontrol_output = (
                 "JobId=2 JobName=test.jcf UserId=root(0) GroupId=root(0) MCS_label=N/A"
                 " Priority=4294901758 Nice=0 Account=root QOS=normal JobState=COMPLETED"
@@ -977,8 +977,8 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "2|root|root|all|1674340451|1674340571|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0||test|node01|01:00:00|bad_wc|2|test.jcf\n"  # noqa
-            sacct_output += "2.batch||||1674340451|1674340571|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0||test|node01|||2.batch|batch"  # noqa
+            sacct_output = "2|root|root|all|1674340451|1674340571|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0|||test|node01|01:00:00|bad_wc|2|test.jcf\n"  # noqa
+            sacct_output += "2.batch||||1674340451|1674340571|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0|||test|node01|||2.batch|batch"  # noqa
             scontrol_output = (
                 "JobId=2 JobName=test.jcf UserId=root(0) GroupId=root(0) MCS_label=N/A"
                 " Priority=4294901758 Nice=0 Account=root QOS=normal JobState=COMPLETED"
@@ -1037,8 +1037,8 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "2|root|root|all|1674340451|bad_ts|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0||test|node01|01:00:00|60|2|test.jcf\n"  # noqa
-            sacct_output += "2.batch||||1674340451|bad_ts|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0||test|node01|||2.batch|batch"  # noqa
+            sacct_output = "2|root|root|all|1674340451|bad_ts|COMPLETED|500M||1|00:00.010|1|/root|00:02:00|0:0|||test|node01|01:00:00|60|2|test.jcf\n"  # noqa
+            sacct_output += "2.batch||||1674340451|bad_ts|COMPLETED||4880K|1|00:00.010|1||00:02:00|0:0|||test|node01|||2.batch|batch"  # noqa
             scontrol_output = (
                 "JobId=2 JobName=test.jcf UserId=root(0) GroupId=root(0) MCS_label=N/A"
                 " Priority=4294901758 Nice=0 Account=root QOS=normal JobState=COMPLETED"
@@ -1096,8 +1096,8 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "3|root|root|all|1674340908|1674340980|TIMEOUT|500M||1|00:00.009|1|/root|00:01:12|0:0||test|node01|00:01:00|1|3|test.jcf\n"  # noqa
-            sacct_output += "3.batch||||1674340908|1674340980|CANCELLED||4876K|1|00:00.009|1||00:01:12|0:15||test|node01|||3.batch|batch"  # noqa
+            sacct_output = "3|root|root|all|1674340908|1674340980|TIMEOUT|500M||1|00:00.009|1|/root|00:01:12|0:0|||test|node01|00:01:00|1|3|test.jcf\n"  # noqa
+            sacct_output += "3.batch||||1674340908|1674340980|CANCELLED||4876K|1|00:00.009|1||00:01:12|0:15|||test|node01|||3.batch|batch"  # noqa
             scontrol_output = (
                 "JobId=3 JobName=test.jcf UserId=root(0) GroupId=root(0) MCS_label=N/A"
                 " Priority=4294901757 Nice=0 Account=root QOS=normal JobState=TIMEOUT"
@@ -1154,8 +1154,8 @@ class TestProcessSpoolFile:
                 }
                 """,
         ):
-            sacct_output = "3|root|root|all|1674770321|Unknown|RUNNING|500M||1|00:00:00|1|/root|00:02:22|0:0||test|node01|00:04:00|4|3|test.jcf\n"  # noqa
-            sacct_output += "3.batch||||1674770321|Unknown|RUNNING|||1|00:00:00|1||00:02:22|0:0||test|node01|||3.batch|batch"  # noqa
+            sacct_output = "3|root|root|all|1674770321|Unknown|RUNNING|500M||1|00:00:00|1|/root|00:02:22|0:0|||test|node01|00:04:00|4|3|test.jcf\n"  # noqa
+            sacct_output += "3.batch||||1674770321|Unknown|RUNNING|||1|00:00:00|1||00:02:22|0:0|||test|node01|||3.batch|batch"  # noqa
             mock_slurmmail_cli_run_command.side_effect = [(0, sacct_output, "")]
             slurmmail.cli.__dict__["__process_spool_file"](
                 pathlib.Path("/tmp/foo"),


### PR DESCRIPTION
Starting SLURM v22.x release, they added a new `Admin Comment` field in additional to `Comment` field, which is only modifiable by Administrator. This is can be useful for Administrator to pass job information to users through the email by setting `AdminComment` via `scontrol` command. 

Although this might not be useful for everyone, I think it would be a good additional for its usefulness and convenience.

The pull request add the additional field extraction and parsing, and only display the information in the job table after the job end.