### PR TITLE
Fix: Favor HTML content instead of plain text

### DIFF
--- a/src/slurmmail/cli.py
+++ b/src/slurmmail/cli.py
@@ -721,8 +721,9 @@ def __process_spool_file(
         msg["From"] = options.email_from_address
         msg["Date"] = email.utils.formatdate(localtime=True)
         msg["Message-ID"] = email.utils.make_msgid()
-        msg.attach(MIMEText(body_html, "html"))
+        # prefer HTML to plain text, so we add the plain text attachment first (see rfc2046 5.1.4)
         msg.attach(MIMEText(body_text, "plain"))
+        msg.attach(MIMEText(body_html, "html"))
         logging.info(
             "Sending e-mail to: %s using %s for job %s (%s) via SMTP server %s:%s",
             job.user,


### PR DESCRIPTION
Hi,

On some email clients, plaintext attachment is shown instead of HTML (eg. Gmail). It is related to the correct interpretation of RFC 2046 5.4:

>  As with "multipart/mixed", the order of body parts is
   significant.  In this case, the alternatives appear in an order of
   increasing faithfulness to the original content.  In general, the
   best choice is the LAST part of a type supported by the recipient
   system's local environment.

To get HTML templates rendered as the default, we must attach plain-text message first, then HTML.
This PR updates the attachment order to get HTML first.