### PR TITLE
Improvement in slurm array mail processing

### DIFF
--- a/src/slurmmail/cli.py
+++ b/src/slurmmail/cli.py
@@ -55,7 +55,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from string import Template
 from time import sleep
-from typing import Dict, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from slurmmail import conf_dir, conf_file, html_tpl_dir, text_tpl_dir
 from slurmmail.common import (
@@ -267,7 +267,7 @@ def __process_spool_file(
 
     user_email = resolved_email
 
-    jobs = []  # store job object for each job in this array
+    jobs: List[Job] = []  # store job object for each job in this array
 
     if state not in [
         "Began",
@@ -371,7 +371,26 @@ def __process_spool_file(
                 if array_summary and "{0}".format(first_job_id) not in sacct_dict["JobId"]:
                     logger.debug("skipping %s for job array summary", sacct_dict["JobId"])
                     continue
-
+                if array_summary and jobs:
+                    logger.info(
+                        "Array summary for %s already has representative task %s;"
+                        "stopping detailed processing",
+                        first_job_id,
+                        jobs[0].id,
+                        )
+                    break
+                if (
+                    not array_summary
+                    and options.array_max_notifications > 0
+                    and len(jobs) >= options.array_max_notifications
+                ):
+                    logger.info(
+                        "Reached array notification processing limit of %d "
+                        "for job %s; stopping detailed task processing",
+                        options.array_max_notifications,
+                        first_job_id,
+                    )
+                    break
                 job = Job(options.datetime_format, job_id, job_raw_id)
 
                 job.cluster = sacct_dict["Cluster"]
@@ -545,10 +564,21 @@ def __process_spool_file(
         # Will only be one job regardless of if it is an array in the
         # "began" state. For jobs that have ended there can be mulitple
         # jobs objects if it is an array.
+        display_job_id = (
+            str(first_job_id)
+            if array_summary
+            else job.id
+        )
+
+        display_array_job_id = (
+            str(first_job_id)
+            if array_summary
+            else job.array_id
+        )
         logger.debug("Creating template for job %s", job.raw_id)
         tpl = Template(get_file_contents(options.html_templates["job_table"]))
         job_table_html = tpl.substitute(
-            JOB_ID=job.id,
+            JOB_ID=display_job_id,
             JOB_NAME=job.name,
             PARTITION=job.partition,
             START=job.start,
@@ -576,7 +606,7 @@ def __process_spool_file(
 
         tpl = Template(get_file_contents(options.text_templates["job_table"]))
         job_table_text = tpl.substitute(
-            JOB_ID=job.id,
+            JOB_ID=display_job_id,
             JOB_NAME=job.name,
             PARTITION=job.partition,
             START=job.start,
@@ -633,8 +663,8 @@ def __process_spool_file(
 
                 body_html = tpl_html.substitute(
                     CSS=options.css,
-                    JOB_ID=job.id,
-                    ARRAY_JOB_ID=job.array_id,
+                    JOB_ID=display_job_id,
+                    ARRAY_JOB_ID=display_array_job_id,
                     USER=job.user_real_name,
                     JOB_TABLE=job_table_html,
                     CLUSTER=job.cluster,
@@ -642,8 +672,8 @@ def __process_spool_file(
                 )
 
                 body_text = tpl_text.substitute(
-                    JOB_ID=job.id,
-                    ARRAY_JOB_ID=job.array_id,
+                    JOB_ID=display_job_id,
+                    ARRAY_JOB_ID=display_array_job_id,
                     USER=job.user_real_name,
                     JOB_TABLE=job_table_text,
                     CLUSTER=job.cluster,
@@ -653,7 +683,7 @@ def __process_spool_file(
                 tpl_html = Template(get_file_contents(options.html_templates["hetjob_started"]))
                 body_html = tpl_html.substitute(
                     CSS=options.css,
-                    JOB_ID=job.id,
+                    JOB_ID=display_job_id,
                     SIGNATURE=signature_html,
                     USER=job.user_real_name,
                     JOB_TABLE=job_table_html,
@@ -661,7 +691,7 @@ def __process_spool_file(
                 )
                 tpl_text = Template(get_file_contents(options.text_templates["hetjob_started"]))
                 body_text = tpl_text.substitute(
-                    JOB_ID=job.id,
+                    JOB_ID=display_job_id,
                     SIGNATURE=signature_text,
                     USER=job.user_real_name,
                     JOB_TABLE=job_table_text,
@@ -671,7 +701,7 @@ def __process_spool_file(
                 tpl_html = Template(get_file_contents(options.html_templates["started"]))
                 body_html = tpl_html.substitute(
                     CSS=options.css,
-                    JOB_ID=job.id,
+                    JOB_ID=display_job_id,
                     SIGNATURE=signature_html,
                     USER=job.user_real_name,
                     JOB_TABLE=job_table_html,
@@ -679,7 +709,7 @@ def __process_spool_file(
                 )
                 tpl_text = Template(get_file_contents(options.text_templates["started"]))
                 body_text = tpl_text.substitute(
-                    JOB_ID=job.id,
+                    JOB_ID=display_job_id,
                     SIGNATURE=signature_text,
                     USER=job.user_real_name,
                     JOB_TABLE=job_table_text,
@@ -748,8 +778,8 @@ def __process_spool_file(
                         body_html = tpl_html.substitute(
                             CSS=options.css,
                             END_TXT=end_txt,
-                            JOB_ID=job.id,
-                            ARRAY_JOB_ID=job.array_id,
+                            JOB_ID=display_job_id,
+                            ARRAY_JOB_ID=display_array_job_id,
                             SIGNATURE=signature_html,
                             USER=job.user_real_name,
                             JOB_TABLE=job_table_html,
@@ -762,8 +792,8 @@ def __process_spool_file(
                         )
                         body_text = tpl_text.substitute(
                             END_TXT=end_txt,
-                            JOB_ID=job.id,
-                            ARRAY_JOB_ID=job.array_id,
+                            JOB_ID=display_job_id,
+                            ARRAY_JOB_ID=display_array_job_id,
                             SIGNATURE=signature_text,
                             USER=job.user_real_name,
                             JOB_TABLE=job_table_text,
@@ -778,8 +808,8 @@ def __process_spool_file(
                         body_html = tpl_html.substitute(
                             CSS=options.css,
                             END_TXT=end_txt,
-                            JOB_ID=job.id,
-                            ARRAY_JOB_ID=job.array_id,
+                            JOB_ID=display_job_id,
+                            ARRAY_JOB_ID=display_array_job_id,
                             SIGNATURE=signature_html,
                             USER=job.user_real_name,
                             JOB_TABLE=job_table_html,
@@ -792,8 +822,8 @@ def __process_spool_file(
                         )
                         body_text = tpl_text.substitute(
                             END_TXT=end_txt,
-                            JOB_ID=job.id,
-                            ARRAY_JOB_ID=job.array_id,
+                            JOB_ID=display_job_id,
+                            ARRAY_JOB_ID=display_array_job_id,
                             SIGNATURE=signature_text,
                             USER=job.user_real_name,
                             JOB_TABLE=job_table_text,
@@ -806,7 +836,7 @@ def __process_spool_file(
                     body_html = tpl_html.substitute(
                         CSS=options.css,
                         END_TXT=end_txt,
-                        JOB_ID=job.id,
+                        JOB_ID=display_job_id,
                         USER=job.user_real_name,
                         JOB_TABLE=job_table_html,
                         JOB_OUTPUT=job_output_html,
@@ -817,7 +847,7 @@ def __process_spool_file(
                     tpl_text = Template(get_file_contents(options.text_templates["hetjob_ended"]))
                     body_text = tpl_text.substitute(
                         END_TXT=end_txt,
-                        JOB_ID=job.id,
+                        JOB_ID=display_job_id,
                         USER=job.user_real_name,
                         JOB_TABLE=job_table_text,
                         TRES_TABLE=tres_template_result.text,
@@ -830,7 +860,7 @@ def __process_spool_file(
                     body_html = tpl_html.substitute(
                         CSS=options.css,
                         END_TXT=end_txt,
-                        JOB_ID=job.id,
+                        JOB_ID=display_job_id,
                         USER=job.user_real_name,
                         JOB_TABLE=job_table_html,
                         TRES_TABLE=tres_template_result.html,
@@ -841,7 +871,7 @@ def __process_spool_file(
                     tpl_text = Template(get_file_contents(options.text_templates["ended"]))
                     body_text = tpl_text.substitute(
                         END_TXT=end_txt,
-                        JOB_ID=job.id,
+                        JOB_ID=display_job_id,
                         USER=job.user_real_name,
                         JOB_TABLE=job_table_text,
                         TRES_TABLE=tres_template_result.text,
@@ -854,7 +884,7 @@ def __process_spool_file(
                 tpl_html = Template(get_file_contents(options.html_templates["never_ran"]))
                 body_html = tpl_html.substitute(
                     CSS=options.css,
-                    JOB_ID=job.id,
+                    JOB_ID=display_job_id,
                     USER=job.user_real_name,
                     JOB_TABLE=job_table_html,
                     CLUSTER=job.cluster,
@@ -862,7 +892,7 @@ def __process_spool_file(
                 )
                 tpl_text = Template(get_file_contents(options.text_templates["never_ran"]))
                 body_text = tpl_text.substitute(
-                    JOB_ID=job.id,
+                    JOB_ID=display_job_id,
                     USER=job.user_real_name,
                     JOB_TABLE=job_table_text,
                     CLUSTER=job.cluster,
@@ -883,7 +913,7 @@ def __process_spool_file(
             body_html = tpl_html.substitute(
                 CSS=options.css,
                 REACHED=reached,
-                JOB_ID=job.id,
+                JOB_ID=display_job_id,
                 REMAINING=remaining_str,
                 USER=job.user_real_name,
                 JOB_TABLE=job_table_html,
@@ -894,7 +924,7 @@ def __process_spool_file(
             tpl_text = Template(get_file_contents(options.text_templates["time"]))
             body_text = tpl_text.substitute(
                 REACHED=reached,
-                JOB_ID=job.id,
+                JOB_ID=display_job_id,
                 REMAINING=remaining_str,
                 USER=job.user_real_name,
                 JOB_TABLE=job_table_text,
@@ -909,7 +939,7 @@ def __process_spool_file(
             body_html = tpl_html.substitute(
                 CSS=options.css,
                 CLUSTER=job.cluster,
-                JOB_ID=job.id,
+                JOB_ID=display_job_id,
                 SIGNATURE=signature_html,
                 USER=job.user_real_name,
                 JOB_TABLE=job_table_html,
@@ -917,7 +947,7 @@ def __process_spool_file(
             tpl_text = Template(get_file_contents(options.text_templates["invalid_dependency"]))
             body_text = tpl_text.substitute(
                 CLUSTER=job.cluster,
-                JOB_ID=job.id,
+                JOB_ID=display_job_id,
                 SIGNATURE=signature_text,
                 USER=job.user_real_name,
                 JOB_TABLE=job_table_text,
@@ -927,7 +957,7 @@ def __process_spool_file(
             body_html = tpl_html.substitute(
                 CSS=options.css,
                 CLUSTER=job.cluster,
-                JOB_ID=job.id,
+                JOB_ID=display_job_id,
                 SIGNATURE=signature_html,
                 USER=job.user_real_name,
                 JOB_TABLE=job_table_html,
@@ -935,7 +965,7 @@ def __process_spool_file(
             tpl_text = Template(get_file_contents(options.text_templates["staged_out"]))
             body_text = tpl_text.substitute(
                 CLUSTER=job.cluster,
-                JOB_ID=job.id,
+                JOB_ID=display_job_id,
                 SIGNATURE=signature_text,
                 USER=job.user_real_name,
                 JOB_TABLE=job_table_text,
@@ -948,7 +978,7 @@ def __process_spool_file(
 
         msg = MIMEMultipart("alternative")
         msg["Subject"] = Template(options.email_subject).substitute(
-            CLUSTER=job.cluster, JOB_ID=job.id, JOB_NAME=job.name, STATE=subject_state
+            CLUSTER=job.cluster, JOB_ID=display_job_id, JOB_NAME=job.name, STATE=subject_state
         )
         msg["To"] = user_email
         msg["From"] = options.email_from_address
@@ -974,7 +1004,7 @@ def __process_spool_file(
             "Sending e-mail to: %s using %s for job %s (%s) via SMTP server %s:%s",
             job.user,
             user_email,
-            job.raw_id,
+            display_job_id,
             state,
             options.smtp_server,
             options.smtp_port,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -602,7 +602,49 @@ class TestProcessSpoolFile:
                 mock_slurmmail_cli_process_spool_file_options,
             )
             mock_slurmmail_cli_delete_spool_file.assert_called_once()
+    def test_array_summary_stops_after_first_representative_task(
+        self,
+        mock_get_file_contents,
+        mock_slurmmail_cli_delete_spool_file,
+        mock_slurmmail_cli_process_spool_file_options,
+        mock_slurmmail_cli_run_command,
+        mock_slurmmail_cli_run_scontrol,
+        mock_smtp_sendmail,
+    ):
+        with tempfile.NamedTemporaryFile(mode="w") as spool_file:
+            spool_file.write("""{
+                "job_id": 1,
+                "email": "root",
+                "state": "Began",
+                "array_summary": true
+            }""")
+            spool_file.flush()
 
+            mock_slurmmail_cli_run_scontrol.return_value = None
+
+            sacct_output = (
+                "1_1|root|root|all|myaccount|1674333232|Unknown|RUNNING|500M||1|0|00:00:00|1|/|00:00:11|0:0|||test|node01|01:00:00|60|1|billing=1,cpu=1,node=1|test.jcf\n"
+                "1_2|root|root|all|myaccount|1674333232|Unknown|RUNNING|500M||1|0|00:00:00|1|/|00:00:11|0:0|||test|node01|01:00:00|60|2|billing=1,cpu=1,node=1|test.jcf\n"
+                "1_3|root|root|all|myaccount|1674333232|Unknown|RUNNING|500M||1|0|00:00:00|1|/|00:00:11|0:0|||test|node01|01:00:00|60|3|billing=1,cpu=1,node=1|test.jcf"
+            )
+
+            mock_slurmmail_cli_run_command.side_effect = [(0, sacct_output, "")]
+
+            slurmmail.cli.__dict__["__process_spool_file"](
+                pathlib.Path(spool_file.name),
+                smtplib.SMTP(),
+                mock_slurmmail_cli_process_spool_file_options,
+            )
+
+            assert mock_slurmmail_cli_run_command.call_count == 1
+            assert mock_slurmmail_cli_run_scontrol.call_count == 1
+            mock_slurmmail_cli_delete_spool_file.assert_called_once()
+            mock_smtp_sendmail.assert_called_once()
+
+            check_templates_used(
+                mock_get_file_contents,
+                ["started-array-summary.tpl", "job-table.tpl", "signature.tpl"],
+            )
     def test_job_began(
         self,
         mock_get_file_contents,
@@ -1396,14 +1438,13 @@ class TestProcessSpoolFile:
             mock_slurmmail_cli_run_command.side_effect = [
                 (0, sacct_output, ""),
                 (0, scontrol_output_1, ""),
-                (0, scontrol_output_2, ""),
             ]
             slurmmail.cli.__dict__["__process_spool_file"](
                 pathlib.Path(spool_file.name),
                 smtplib.SMTP(),
                 mock_slurmmail_cli_process_spool_file_options,
             )
-            assert mock_slurmmail_cli_run_command.call_count == 3
+            assert mock_slurmmail_cli_run_command.call_count == 2
             mock_slurmmail_cli_delete_spool_file.assert_called_once()
             mock_smtp_sendmail.assert_called_once()
             assert (


### PR DESCRIPTION
The change avoids unnecessary detailed processing once an array-summary notification already has a representative task. Previously, array summary processing could continue walking additional sacct rows even though only the first job object is ultimately used for the email. This can generate unnecessary burden on the database via unused scontrol calls.

Second change was to ensure that they array summary emails showed the parent array job ID rather than a specific child array job ID. 

Also added a unit test to check early termination for array summary processing. 

Caveat: The summary email still uses one representative child task for job details such as stdout/stderr paths and other task-specific fields. However, the displayed job ID is now the parent array job ID, which should be clearer for users.